### PR TITLE
Google sign in test, iOS

### DIFF
--- a/packages/google_sign_in/google_sign_in/example/ios/GoogleSignInExampleTests/Info.plist
+++ b/packages/google_sign_in/google_sign_in/example/ios/GoogleSignInExampleTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/packages/google_sign_in/google_sign_in/ios/Tests/GoogleSignInExampleTests.m
+++ b/packages/google_sign_in/google_sign_in/ios/Tests/GoogleSignInExampleTests.m
@@ -1,0 +1,54 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import Flutter;
+
+@import XCTest;
+@import google_sign_in;
+@import GoogleSignIn;
+@import OCMock;
+
+@interface FLTGoogleSignInPluginTest : XCTestCase
+
+@property(strong, nonatomic) NSObject<FlutterBinaryMessenger> *mockBinaryMessenger;
+@property(strong, nonatomic) NSObject<FlutterPluginRegistrar> *mockPluginRegistrar;
+@property(strong, nonatomic) FLTGoogleSignInPlugin *plugin;
+@property(strong, nonatomic) GIDSignIn *mockSharedInstance;
+
+@end
+
+@implementation FLTGoogleSignInPluginTest
+
+- (void)setUp {
+  [super setUp];
+  self.mockBinaryMessenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  self.mockPluginRegistrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
+  self.mockSharedInstance = [OCMockObject partialMockForObject:[GIDSignIn sharedInstance]];
+  OCMStub(self.mockPluginRegistrar.messenger).andReturn(self.mockBinaryMessenger);
+  self.plugin = [[FLTGoogleSignInPlugin alloc] init];
+  [FLTGoogleSignInPlugin registerWithRegistrar:self.mockPluginRegistrar];
+}
+
+- (void)testRequestScopesIfNoMissingScope {
+  // Mock Google Signin internal calls
+  GIDGoogleUser *mockUser = OCMClassMock(GIDGoogleUser.class);
+  OCMStub(self.mockSharedInstance.currentUser).andReturn(mockUser);
+  NSArray *currentScopes = @[@"mockScope1"];
+  OCMStub(mockUser.grantedScopes).andReturn(currentScopes);
+  FlutterMethodCall *methodCall = [FlutterMethodCall methodCallWithMethodName:@"requestScopes" arguments:@{@"scopes":currentScopes}];
+
+  XCTestExpectation* expectation =
+      [self expectationWithDescription:@"expect result returns true"];
+  __block id result;
+  [self.plugin handleMethodCall:methodCall
+                         result:^(id r) {
+                           [expectation fulfill];
+                           result = r;
+                         }];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertTrue([result boolValue]);
+
+}
+
+@end

--- a/packages/google_sign_in/google_sign_in/ios/google_sign_in.podspec
+++ b/packages/google_sign_in/google_sign_in/ios/google_sign_in.podspec
@@ -20,4 +20,9 @@ Enables Google Sign-In in Flutter apps.
 
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*'
+    test_spec.dependency 'OCMock','3.5'
+  end
 end


### PR DESCRIPTION
## Description

I added a sample test for the requestScopes API on iOS. You should be able to add more tests following the sample given your needs.
To run the iOS tests: 
```
cd packages/google_sign_in/google_sign_in/ios
pod lib lint --allow-warnings
```
Let me know if you can't run the tests or the test is failing for you.

